### PR TITLE
[102] Move the resources attribute to the value attribute and created…

### DIFF
--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -54,7 +54,7 @@ For simple tests, you can specify resource classes directly:
 
 [source,java]
 ----
-@RestBootstrap(resources = HelloResource.class)
+@RestBootstrap(HelloResource.class)
 public class HelloResourceTest {
 
     @RestResource
@@ -125,7 +125,7 @@ For simple tests, specify Jakarta REST resource classes directly:
 
 [source,java]
 ----
-@RestBootstrap(resources = {UserResource.class, OrderResource.class})
+@RestBootstrap({UserResource.class, OrderResource.class})
 public class MyTest {
     // Tests run with a synthetic Application containing these resources
 }
@@ -139,7 +139,7 @@ For more control, specify a custom `Application` class:
 
 [source,java]
 ----
-@RestBootstrap(MyApplication.class)
+@RestBootstrap(application = MyApplication.class)
 public class MyTest {
     // Tests run with MyApplication
 }
@@ -154,12 +154,12 @@ Use this when you need:
 
 ==== Mutual Exclusivity
 
-**Important:** Exactly one of `value()` or `resources()` must be specified. Specifying both or neither will result in an error.
+**Important:** Exactly one of `value()` or `application()` must be specified. Specifying both or neither will result in an error.
 
 **Attributes:**
 
-* `value` - The Jakarta REST `Application` class to bootstrap (mutually exclusive with `resources`)
-* `resources` - Jakarta REST resource classes to bootstrap (mutually exclusive with `value`)
+* `application` - The Jakarta REST `Application` class to bootstrap (mutually exclusive with `value`)
+* `value` - Jakarta REST resource classes to bootstrap (mutually exclusive with `application`)
 * `configFactory` - Optional `ConfigurationProvider` for custom server configuration
 * `timeout` - Startup/shutdown timeout (default: 60 seconds)
 * `timeoutUnit` - Timeout time unit (default: `SECONDS`)
@@ -555,16 +555,16 @@ When determining which configuration to use, the extension follows this preceden
 . **Configuration parameters** (`dev.resteasy.junit.extension.*` properties)
 . **SeBootstrap defaults** (random port, localhost, http, root path /)
 
-=== Choosing Between `value()` and `resources()`
+=== Choosing Between `value()` and `application()`
 
 Here's a comparison to help you decide which approach to use:
 
-**Use `resources()` when:**
+**Use `value()` when:**
 
 [source,java]
 ----
 // Simple test with just resource classes
-@RestBootstrap(resources = {UserResource.class, OrderResource.class})
+@RestBootstrap({UserResource.class, OrderResource.class})
 public class SimpleApiTest {
     @RestResource
     private WebTarget target;
@@ -577,7 +577,7 @@ public class SimpleApiTest {
 }
 ----
 
-**Use `value()` when you need more control:**
+**Use `application()` when you need more control:**
 
 [source,java]
 ----
@@ -595,7 +595,7 @@ public class MyApplication extends Application {
     }
 }
 
-@RestBootstrap(MyApplication.class)
+@RestBootstrap(application = MyApplication.class)
 public class AdvancedApiTest {
     @RestResource
     @RequestPath("/api/app/")

--- a/extension/src/main/java/dev/resteasy/junit/extension/annotations/RestBootstrap.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/annotations/RestBootstrap.java
@@ -29,20 +29,20 @@ import dev.resteasy.junit.extension.extensions.UriBuilderParameterResolver;
  * There are two ways to specify what to bootstrap:
  * </p>
  * <ol>
- * <li><strong>Application class</strong> - Specify a custom {@link Application} class via {@link #value()}:
+ * <li><strong>Application class</strong> - Specify a custom {@link Application} class via {@link #application()}:
  *
  * <pre>
- * &#64;RestBootstrap(MyApplication.class)
+ * &#64;RestBootstrap(application = MyApplication.class)
  * public class MyTest {
  *     // Tests run with MyApplication
  * }
  * </pre>
  *
  * </li>
- * <li><strong>Resource classes</strong> - For simple cases, specify Jakarta REST resource classes via {@link #resources()}:
+ * <li><strong>Resource classes</strong> - For simple cases, specify Jakarta REST resource classes via {@link #value()}:
  *
  * <pre>
- * &#64;RestBootstrap(resources = { UserResource.class, OrderResource.class })
+ * &#64;RestBootstrap({ UserResource.class, OrderResource.class })
  * public class MyTest {
  *     // Tests run with a synthetic Application containing these resources
  * }
@@ -51,7 +51,7 @@ import dev.resteasy.junit.extension.extensions.UriBuilderParameterResolver;
  * </li>
  * </ol>
  * <p>
- * Exactly one of {@link #value()} or {@link #resources()} must be specified. Specifying both or neither will result
+ * Exactly one of {@link #application()} or {@link #value()} must be specified. Specifying both or neither will result
  * in an {@link org.junit.jupiter.api.extension.ExtensionConfigurationException}.
  * </p>
  * <p>
@@ -74,37 +74,21 @@ import dev.resteasy.junit.extension.extensions.UriBuilderParameterResolver;
 public @interface RestBootstrap {
 
     /**
-     * The {@linkplain Application application} to use for
-     * {@linkplain SeBootstrap#start(Class, SeBootstrap.Configuration) starting} a
-     * {@link SeBootstrap.Instance}.
-     * <p>
-     * This is mutually exclusive with {@link #resources()}. Exactly one must be specified.
-     * </p>
-     * <p>
-     * The default value of {@link Application}.class serves as a marker indicating no application was specified.
-     * In this case, {@link #resources()} must be non-empty.
-     * </p>
-     *
-     * @return the application class, or {@link Application}.class if using {@link #resources()} instead
-     */
-    Class<? extends Application> value() default Application.class;
-
-    /**
      * Jakarta REST resource classes to bootstrap for testing.
      * <p>
-     * This provides a simplified alternative to {@link #value()} for common cases where you only need to specify
-     * resource classes without custom {@link Application} configuration. When {@code resources()} is specified,
+     * This provides a simplified alternative to {@link #application()} for common cases where you only need to specify
+     * resource classes without custom {@link Application} configuration. When {@code value()} is specified,
      * the extension creates a synthetic {@link Application} that returns these classes from
      * {@link Application#getClasses()}.
      * </p>
      * <p>
-     * This is mutually exclusive with {@link #value()}. Exactly one must be specified.
+     * This is mutually exclusive with {@link #application()}. Exactly one must be specified.
      * </p>
      *
      * <h3>Example</h3>
      *
      * <pre>
-     * &#64;RestBootstrap(resources = { UserResource.class, OrderResource.class })
+     * &#64;RestBootstrap({ UserResource.class, OrderResource.class })
      * public class SimpleTest {
      *     &#64;RestResource
      *     private Client client;
@@ -117,11 +101,11 @@ public @interface RestBootstrap {
      * </pre>
      *
      * <p>
-     * <strong>When to use {@code resources()} vs {@code value()}:</strong>
+     * <strong>When to use {@code value()} vs {@code application()}:</strong>
      * </p>
      * <ul>
-     * <li>Use {@code resources()} for simple tests that only need to specify resource classes</li>
-     * <li>Use {@code value()} when you need:
+     * <li>Use {@code value()} for simple tests that only need to specify resource classes</li>
+     * <li>Use {@code application()} when you need:
      * <ul>
      * <li>Custom {@link jakarta.ws.rs.ApplicationPath} configuration</li>
      * <li>Custom {@link Application} properties</li>
@@ -130,9 +114,25 @@ public @interface RestBootstrap {
      * </li>
      * </ul>
      *
-     * @return an array of Jakarta REST resource classes, or empty if using {@link #value()} instead
+     * @return an array of Jakarta REST resource classes, or empty if using {@link #application()} instead
      */
-    Class<?>[] resources() default {};
+    Class<?>[] value() default {};
+
+    /**
+     * The {@linkplain Application application} to use for
+     * {@linkplain SeBootstrap#start(Class, SeBootstrap.Configuration) starting} a
+     * {@link SeBootstrap.Instance}.
+     * <p>
+     * This is mutually exclusive with {@link #value()}. Exactly one must be specified.
+     * </p>
+     * <p>
+     * The default value of {@link Application}.class serves as a marker indicating no application was specified.
+     * In this case, {@link #value()} must be non-empty.
+     * </p>
+     *
+     * @return the application class, or {@link Application}.class if using {@link #value()} instead
+     */
+    Class<? extends Application> application() default Application.class;
 
     /**
      * A factory used to be build the {@linkplain SeBootstrap.Configuration configuration} for starting the

--- a/extension/src/main/java/dev/resteasy/junit/extension/extensions/InstanceManager.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/extensions/InstanceManager.java
@@ -100,8 +100,8 @@ class InstanceManager implements ExtensionContext.Store.CloseableResource, AutoC
                     DefaultConfigurationProvider::new);
             final SeBootstrap.Configuration configuration = factory.getConfiguration(context);
             final CompletionStage<SeBootstrap.Instance> stage;
-            if (bootstrap.value() == Application.class) {
-                final Set<Class<?>> resources = Set.of(bootstrap.resources());
+            if (bootstrap.application() == Application.class) {
+                final Set<Class<?>> resources = Set.of(bootstrap.value());
                 stage = SeBootstrap.start(new Application() {
                     @Override
                     public Set<Class<?>> getClasses() {
@@ -109,7 +109,7 @@ class InstanceManager implements ExtensionContext.Store.CloseableResource, AutoC
                     }
                 }, configuration);
             } else {
-                stage = SeBootstrap.start(bootstrap.value(), configuration);
+                stage = SeBootstrap.start(bootstrap.application(), configuration);
             }
             holder.instance = stage.toCompletableFuture()
                     .get(bootstrap.timeout(), bootstrap.timeoutUnit());

--- a/extension/src/main/java/dev/resteasy/junit/extension/extensions/SeBootstrapExtension.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/extensions/SeBootstrapExtension.java
@@ -29,13 +29,13 @@ public class SeBootstrapExtension implements BeforeAllCallback {
             return;
         }
         final RestBootstrap restBootstrap = bootstrap.get();
-        // Validate the RestBootstrap annotation. Only the value() or the resources() can be defined, but not both
-        if (restBootstrap.value() == Application.class && restBootstrap.resources().length == 0) {
+        // Validate the RestBootstrap annotation. Only the value() or the application() can be defined, but not both
+        if (restBootstrap.application() == Application.class && restBootstrap.value().length == 0) {
             throw new ExtensionConfigurationException(
-                    "Must define either a Jakarta REST Application in the value or Jakarta REST resources in the resources.");
+                    "Must define either a Jakarta REST Application via application() or Jakarta REST resource classes via value().");
         }
-        if (restBootstrap.value() != Application.class && restBootstrap.resources().length > 0) {
-            throw new ExtensionConfigurationException("Only the value() or resources() is allowed to be defined.");
+        if (restBootstrap.application() != Application.class && restBootstrap.value().length > 0) {
+            throw new ExtensionConfigurationException("Only the value() or application() is allowed to be defined.");
         }
         InstanceManager.getOrCreateInstance(context, testClass, restBootstrap).startInstance(context);
     }

--- a/extension/src/main/java/module-info.java
+++ b/extension/src/main/java/module-info.java
@@ -23,7 +23,7 @@
  * <h2>Usage Example</h2>
  * <!-- @formatter:off -->
  * {@snippet :
- * @RestBootstrap(MyApplication.class)
+ * @RestBootstrap(HelloResource.class)
  * public class HelloResourceTest {
  *
  *     @RestResource

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/ClientInstanceTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/ClientInstanceTest.java
@@ -25,7 +25,7 @@ import dev.resteasy.junit.extension.extension.resources.TestApplication;
  *
  * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
-@RestBootstrap(TestApplication.class)
+@RestBootstrap(application = TestApplication.class)
 public class ClientInstanceTest {
 
     @RestResource
@@ -112,7 +112,7 @@ public class ClientInstanceTest {
     }
 
     @Nested
-    @RestBootstrap(value = TestApplication.class, configFactory = SecondInstanceConfigurationProvider.class)
+    @RestBootstrap(application = TestApplication.class, configFactory = SecondInstanceConfigurationProvider.class)
     @Disabled("Disable until we can upgrade to RESTEasy 6.2.17.Final")
     class NestedWithBootstrap {
         @RestResource

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/ClientTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/ClientTest.java
@@ -21,7 +21,7 @@ import dev.resteasy.junit.extension.extension.resources.TestApplication;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(TestApplication.class)
+@RestBootstrap(application = TestApplication.class)
 public class ClientTest {
 
     @RestResource

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/CustomRestResourceProducerTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/CustomRestResourceProducerTest.java
@@ -81,7 +81,7 @@ public class CustomRestResourceProducerTest {
      * using EngineTestKit to verify that custom producers work end-to-end.
      * </p>
      */
-    @RestBootstrap(TestApplication.class)
+    @RestBootstrap(application = TestApplication.class)
     public static class TestClassUsingCustomProducer {
 
         @RestResource

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/MethodScopedResourceTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/MethodScopedResourceTest.java
@@ -26,7 +26,7 @@ import dev.resteasy.junit.extension.extension.resources.TestApplication;
  *
  * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
-@RestBootstrap(TestApplication.class)
+@RestBootstrap(application = TestApplication.class)
 public class MethodScopedResourceTest {
     private static final Path TEMP_FILE = Path.of(System.getProperty("java.io.tmpdir"), "test.tmp");
 

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/ResourceScopeTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/ResourceScopeTest.java
@@ -135,7 +135,7 @@ public class ResourceScopeTest {
     /**
      * Test class using DEFAULT-scoped resources.
      */
-    @RestBootstrap(TestApplication.class)
+    @RestBootstrap(application = TestApplication.class)
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @SuppressWarnings("NewClassNamingConvention")
     public static class DefaultScopeTestClass {
@@ -174,7 +174,7 @@ public class ResourceScopeTest {
     /**
      * Test class using CLASS-scoped resources.
      */
-    @RestBootstrap(TestApplication.class)
+    @RestBootstrap(application = TestApplication.class)
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @SuppressWarnings("NewClassNamingConvention")
     public static class ClassScopeTestClass {

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/RestBootstrapValidationTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/RestBootstrapValidationTest.java
@@ -26,7 +26,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
 
 /**
  * Tests validation of {@link RestBootstrap} annotation to ensure mutual exclusivity of {@code value()} and
- * {@code resources()}.
+ * {@code application()}.
  *
  * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
@@ -49,7 +49,7 @@ public class RestBootstrapValidationTest {
     }
 
     /**
-     * Test class with neither value() nor resources() specified - should fail.
+     * Test class with neither value() nor application() specified - should fail.
      */
     @RestBootstrap
     public static class NeitherSpecifiedTest {
@@ -60,9 +60,9 @@ public class RestBootstrapValidationTest {
     }
 
     /**
-     * Test class with both value() and resources() specified - should fail.
+     * Test class with both value() and application() specified - should fail.
      */
-    @RestBootstrap(value = TestApplication.class, resources = { TestResource.class })
+    @RestBootstrap(application = TestApplication.class, value = TestResource.class)
     public static class BothSpecifiedTest {
         @Test
         public void test() {
@@ -71,10 +71,10 @@ public class RestBootstrapValidationTest {
     }
 
     /**
-     * Test class with only value() specified - should succeed.
+     * Test class with only application() specified - should succeed.
      */
-    @RestBootstrap(TestApplication.class)
-    public static class OnlyValueSpecifiedTest {
+    @RestBootstrap(application = TestApplication.class)
+    public static class OnlyApplicationSpecifiedTest {
 
         @RestResource
         @RequestPath("test-api/test")
@@ -91,10 +91,10 @@ public class RestBootstrapValidationTest {
     }
 
     /**
-     * Test class with only resources() specified - should succeed.
+     * Test class with only value() specified - should succeed.
      */
-    @RestBootstrap(resources = { TestResource.class })
-    public static class OnlyResourcesSpecifiedTest {
+    @RestBootstrap(TestResource.class)
+    public static class OnlyValueSpecifiedTest {
 
         @RestResource
         @RequestPath("test")
@@ -111,7 +111,7 @@ public class RestBootstrapValidationTest {
     }
 
     @Test
-    public void neitherValueNorResourcesSpecified() {
+    public void neitherValueNorApplicationSpecified() {
         final var results = EngineTestKit
                 .engine("junit-jupiter")
                 .selectors(DiscoverySelectors.selectClass(NeitherSpecifiedTest.class))
@@ -132,12 +132,12 @@ public class RestBootstrapValidationTest {
                     return throwable.isPresent()
                             && throwable.get().getMessage()
                                     .contains(
-                                            "Must define either a Jakarta REST Application in the value or Jakarta REST resources in the resources");
+                                            "Must define either a Jakarta REST Application via application() or Jakarta REST resource classes via value().");
                 });
     }
 
     @Test
-    public void bothValueAndResourcesSpecified() {
+    public void bothValueAndApplicationSpecified() {
         final var results = EngineTestKit
                 .engine("junit-jupiter")
                 .selectors(DiscoverySelectors.selectClass(BothSpecifiedTest.class))
@@ -157,8 +157,18 @@ public class RestBootstrapValidationTest {
                             .flatMap(TestExecutionResult::getThrowable);
                     return throwable.isPresent()
                             && throwable.get().getMessage()
-                                    .contains("Only the value() or resources() is allowed to be defined");
+                                    .contains("Only the value() or application() is allowed to be defined");
                 });
+    }
+
+    @Test
+    public void onlyApplicationSpecified() {
+        EngineTestKit
+                .engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(OnlyApplicationSpecifiedTest.class))
+                .execute()
+                .testEvents()
+                .assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
     }
 
     @Test
@@ -166,16 +176,6 @@ public class RestBootstrapValidationTest {
         EngineTestKit
                 .engine("junit-jupiter")
                 .selectors(DiscoverySelectors.selectClass(OnlyValueSpecifiedTest.class))
-                .execute()
-                .testEvents()
-                .assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
-    }
-
-    @Test
-    public void onlyResourcesSpecified() {
-        EngineTestKit
-                .engine("junit-jupiter")
-                .selectors(DiscoverySelectors.selectClass(OnlyResourcesSpecifiedTest.class))
                 .execute()
                 .testEvents()
                 .assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/SeBootstrapTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/SeBootstrapTest.java
@@ -27,7 +27,7 @@ import dev.resteasy.junit.extension.extension.resources.TestApplication;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(value = TestApplication.class, configFactory = SeBootstrapTest.PortChangeConfigurationFactory.class)
+@RestBootstrap(application = TestApplication.class, configFactory = SeBootstrapTest.PortChangeConfigurationFactory.class)
 public class SeBootstrapTest {
     public static class PortChangeConfigurationFactory implements ConfigurationProvider {
         @Override

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/SharedConfigInstanceTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/SharedConfigInstanceTest.java
@@ -22,7 +22,7 @@ import dev.resteasy.junit.extension.extension.resources.TestApplication;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(TestApplication.class)
+@RestBootstrap(application = TestApplication.class)
 public class SharedConfigInstanceTest {
     private static final AtomicReference<Configuration> CONFIGURATION = new AtomicReference<>();
 
@@ -76,7 +76,7 @@ public class SharedConfigInstanceTest {
     }
 
     @Nested
-    @RestBootstrap(value = TestApplication.class, configFactory = SecondInstanceConfigurationProvider.class)
+    @RestBootstrap(application = TestApplication.class, configFactory = SecondInstanceConfigurationProvider.class)
     @Disabled("Disable until we can upgrade to RESTEasy 6.2.17.Final")
     class NestedWithBootstrap {
         @RestResource

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/TemplateBootstrapTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/TemplateBootstrapTest.java
@@ -30,7 +30,7 @@ import dev.resteasy.junit.extension.extension.resources.EchoResource;
  *
  * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
-@RestBootstrap(resources = EchoResource.class)
+@RestBootstrap(value = EchoResource.class)
 class TemplateBootstrapTest {
 
     @RestResource

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/UriBuilderTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/UriBuilderTest.java
@@ -24,7 +24,7 @@ import dev.resteasy.junit.extension.extension.resources.TestApplication;
  *
  * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
-@RestBootstrap(TestApplication.class)
+@RestBootstrap(application = TestApplication.class)
 public class UriBuilderTest {
 
     @RestResource

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/UriInjectionTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/UriInjectionTest.java
@@ -25,7 +25,7 @@ import dev.resteasy.junit.extension.extension.resources.TestApplication;
  *
  * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
-@RestBootstrap(TestApplication.class)
+@RestBootstrap(application = TestApplication.class)
 public class UriInjectionTest {
 
     @RestResource

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/WebTargetTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/WebTargetTest.java
@@ -22,7 +22,7 @@ import dev.resteasy.junit.extension.extension.resources.TestApplication;
  *
  * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
-@RestBootstrap(TestApplication.class)
+@RestBootstrap(application = TestApplication.class)
 public class WebTargetTest {
 
     @RestResource

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/WebTargetWithoutPathTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/WebTargetWithoutPathTest.java
@@ -23,7 +23,7 @@ import dev.resteasy.junit.extension.extension.resources.TestApplication;
  *
  * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
-@RestBootstrap(TestApplication.class)
+@RestBootstrap(application = TestApplication.class)
 public class WebTargetWithoutPathTest {
 
     @RestResource

--- a/testsuite/wildfly-integration-tests/src/test/java/dev/resteasy/junit/extension/integration/test/ArquillianIntegrationTest.java
+++ b/testsuite/wildfly-integration-tests/src/test/java/dev/resteasy/junit/extension/integration/test/ArquillianIntegrationTest.java
@@ -40,7 +40,7 @@ import dev.resteasy.junit.extension.annotations.RestResource;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@RestBootstrap(ArquillianIntegrationTest.SeApplication.class)
+@RestBootstrap(application = ArquillianIntegrationTest.SeApplication.class)
 @ExtendWith(ArquillianExtension.class)
 @ApplicationScoped
 public class ArquillianIntegrationTest {


### PR DESCRIPTION
… a application attribute, which was previously the value. This is to avoid confusion on resources only being REST resources, but they could also be providers.

resolves #102 