### PR TITLE
Add SSL/TLS testing support via @SelfSignedCert annotation

### DIFF
--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -161,6 +161,7 @@ Use this when you need:
 * `application` - The Jakarta REST `Application` class to bootstrap (mutually exclusive with `value`)
 * `value` - Jakarta REST resource classes to bootstrap (mutually exclusive with `application`)
 * `configFactory` - Optional `ConfigurationProvider` for custom server configuration
+* `sslClientAuthentication` - SSL client authentication mode when using `@SelfSignedCert` (default: `OPTIONAL`). See <<ssl-testing>>.
 * `timeout` - Startup/shutdown timeout (default: 60 seconds)
 * `timeoutUnit` - Timeout time unit (default: `SECONDS`)
 
@@ -190,6 +191,10 @@ The extension can inject several types into your tests:
 
 |`jakarta.ws.rs.SeBootstrap.Configuration`
 |The SeBootstrap configuration
+|Fields, Parameters
+
+|`dev.resteasy.junit.extension.api.SelfSignedCertificate`
+|Self-signed certificate artifacts (requires `@SelfSignedCert` on class, `@SslCert` on field)
 |Fields, Parameters
 |===
 
@@ -354,6 +359,243 @@ public class CustomPortProvider implements ConfigurationProvider {
 public class CustomPortTest {
     // Tests run on port 9090
     // Configuration parameters are ignored when configFactory is specified
+}
+----
+
+[[ssl-testing]]
+
+=== SSL/TLS Testing
+
+The extension provides built-in support for SSL/TLS testing with self-signed certificates. No external certificate
+setup or keystore configuration is required.
+
+==== Quick Start
+
+Add `@SelfSignedCert` alongside `@RestBootstrap` to start the server on HTTPS with auto-configured SSL:
+
+[source,java]
+----
+@SelfSignedCert
+@RestBootstrap(MyResource.class)
+public class SslTest {
+
+    @RestResource
+    private Client client;  // auto-configured with client SSL context
+
+    @RestResource
+    private URI baseUri;
+
+    @Test
+    public void testHttps() {
+        assertEquals("https", baseUri.getScheme());
+        Response response = client.target(baseUri)
+            .path("/hello")
+            .request()
+            .get();
+        assertEquals(200, response.getStatus());
+    }
+}
+----
+
+When `@SelfSignedCert` is present alongside `@RestBootstrap`, the extension automatically:
+
+* Generates self-signed server and client certificates using the JDK `keytool`
+* Starts the `SeBootstrap` instance with HTTPS and the server SSL context
+* Configures injected `Client` and `WebTarget` instances with the client SSL context
+* Cleans up all generated keystore files after the test run
+* Tags the test class with `ssl-test` for JUnit tag filtering
+
+TIP: Use the `ssl-test` tag to include or exclude SSL tests. For example, with Maven Surefire:
+`mvn test -Dgroups=ssl-test` (run only SSL tests) or `mvn test -DexcludedGroups=ssl-test` (skip SSL tests).
+
+==== Accessing Certificate Artifacts
+
+For advanced scenarios — such as configuring a non-Jakarta REST HTTP client or verifying certificate details — inject the
+`SelfSignedCertificate` using `@SslCert`:
+
+[source,java]
+----
+@SelfSignedCert
+@RestBootstrap(MyResource.class)
+public class SslTest {
+
+    @SslCert
+    private SelfSignedCertificate certificate;
+
+    @RestResource
+    @RequestPath("hello")
+    private URI uri;
+
+    @Test
+    public void testWithHttpClient() throws Exception {
+        HttpClient httpClient = HttpClient.newBuilder()
+            .sslContext(certificate.clientSslContext())
+            .build();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(uri)
+            .GET()
+            .build();
+        HttpResponse<String> response = httpClient.send(request,
+            HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+    }
+
+    @Test
+    public void testWithKeyStoreApi() {
+        try (Client client = ClientBuilder.newBuilder()
+                .keyStore(certificate.clientKeyStore(),
+                    SelfSignedCertificate.KEYSTORE_PASSWORD)
+                .trustStore(certificate.clientTrustStore())
+                .build()) {
+            // Use client...
+        }
+    }
+}
+----
+
+The `SelfSignedCertificate` interface provides:
+
+[cols="1,3"]
+|===
+|Method |Description
+
+|`clientSslContext()` / `serverSslContext()`
+|Pre-configured `SSLContext` instances
+
+|`clientKeyStore()` / `serverKeyStore()`
+|`KeyStore` objects containing the private key and certificate
+
+|`clientTrustStore()` / `serverTrustStore()`
+|`KeyStore` objects containing the trusted peer's certificate
+
+|`clientKeyStorePath()` / `serverKeyStorePath()`
+|`Path` to the keystore files on disk
+
+|`clientTrustStorePath()` / `serverTrustStorePath()`
+|`Path` to the truststore files on disk
+
+|`keyStorePassword()`
+|The password used for all generated stores
+
+|`keyStoreType()`
+|The keystore type (e.g., `PKCS12`)
+|===
+
+==== Standalone Certificate Usage
+
+`@SelfSignedCert` can be used independently of `@RestBootstrap` when only certificate artifacts are needed:
+
+[source,java]
+----
+@SelfSignedCert
+public class StandaloneCertTest {
+
+    @SslCert
+    private SelfSignedCertificate certificate;
+
+    @Test
+    public void testCertificate() {
+        assertNotNull(certificate.serverSslContext());
+        assertNotNull(certificate.clientSslContext());
+        assertTrue(Files.exists(certificate.serverKeyStorePath()));
+    }
+}
+----
+
+==== SSL Client Authentication
+
+The `sslClientAuthentication` attribute on `@RestBootstrap` controls whether the server requires client certificates
+during the TLS handshake:
+
+[source,java]
+----
+@SelfSignedCert
+@RestBootstrap(value = MyResource.class,
+    sslClientAuthentication = SSLClientAuthentication.MANDATORY)
+public class MutualTlsTest {
+
+    @RestResource
+    private Client client;  // configured with full client cert
+
+    @RestResource
+    private URI baseUri;
+
+    @Test
+    public void clientWithCertSucceeds() {
+        // Injected client has client SSL context — succeeds
+        Response response = client.target(baseUri)
+            .path("/hello")
+            .request()
+            .get();
+        assertEquals(200, response.getStatus());
+    }
+}
+----
+
+**Available modes:**
+
+* `SSLClientAuthentication.OPTIONAL` (default) — Server requests a client certificate but does not require one. This
+  is the recommended default since the injected client is always configured with the client SSL context.
+* `SSLClientAuthentication.MANDATORY` — Server requires a valid client certificate. Connections without one are
+  rejected.
+* `SSLClientAuthentication.NONE` — Server does not request a client certificate.
+
+NOTE: The `sslClientAuthentication` attribute is only used by the default `ConfigurationProvider`. Custom providers
+specified via `configFactory` are responsible for their own SSL client authentication configuration.
+
+==== Custom SSL Configuration
+
+For full control over SSL configuration, use `@SslCert` field injection in custom providers:
+
+**Custom Server Configuration:**
+
+[source,java]
+----
+public class CustomSslConfigProvider implements ConfigurationProvider {
+    @SslCert
+    private SelfSignedCertificate certificate;
+
+    @Override
+    public SeBootstrap.Configuration getConfiguration(ExtensionContext context) {
+        return SeBootstrap.Configuration.builder()
+                .protocol("HTTPS")
+                .sslContext(certificate.serverSslContext())
+                .port(9443)
+                .build();
+    }
+}
+
+@SelfSignedCert
+@RestBootstrap(value = MyResource.class,
+    configFactory = CustomSslConfigProvider.class)
+public class CustomSslTest {
+    // Server runs on HTTPS port 9443 with custom configuration
+}
+----
+
+**Custom Client Configuration:**
+
+[source,java]
+----
+public class CustomSslClientProvider implements RestClientBuilderProvider {
+    @SslCert
+    private SelfSignedCertificate certificate;
+
+    @Override
+    public ClientBuilder getClientBuilder() {
+        return ClientBuilder.newBuilder()
+                .sslContext(certificate.clientSslContext())
+                .connectTimeout(5, TimeUnit.SECONDS);
+    }
+}
+
+@SelfSignedCert
+@RestBootstrap(MyResource.class)
+public class CustomSslClientTest {
+
+    @RestResource
+    @RestClientConfig(CustomSslClientProvider.class)
+    private Client sslClient;  // custom SSL + timeout config
 }
 ----
 
@@ -622,6 +864,11 @@ Complete working examples can be found in the link:https://github.com/resteasy/r
 * **`CustomRestResourceProducerTest`** - Custom `RestResourceProducer` implementation
 * **`ResourceScopeTest`** - Resource lifecycle scoping (CLASS vs DEFAULT)
 * **`MethodScopedResourceTest`** - Practical example of method-scoped temporary files
+* **`SslBootstrapTest`** - `@SelfSignedCert` with `@RestBootstrap` for HTTPS testing
+* **`SelfSignedCertStandaloneTest`** - Standalone certificate usage without `@RestBootstrap`
+* **`SslClientAuthenticationTest`** - `SSLClientAuthentication` modes (OPTIONAL, MANDATORY, NONE)
+* **`SslCustomConfigProviderTest`** - Custom `ConfigurationProvider` with `@SslCert` injection
+* **`SslCustomClientProviderTest`** - Custom `RestClientBuilderProvider` with `@SslCert` injection
 
 == Configuration Reference
 
@@ -701,6 +948,20 @@ A: Ensure your test class is annotated with `@RestBootstrap` and that you have a
 **Q: Can nested test classes have different configurations?**
 
 A: Yes! Add `@RestBootstrap` with a custom `configFactory` to the nested class. However, note that some Jakarta REST implementations (like RESTEasy with CDI) may not support running multiple `SeBootstrap` instances simultaneously due to singleton container limitations.
+
+**Q: How do I test with HTTPS/SSL?**
+
+A: Add `@SelfSignedCert` alongside `@RestBootstrap` on your test class. The extension generates self-signed certificates and configures HTTPS automatically. See <<ssl-testing>> for details and examples.
+
+**Q: Can I use my own certificates instead of auto-generated ones?**
+
+A: Yes. Implement a custom `ConfigurationProvider` (for the server) and/or `RestClientBuilderProvider` (for the client) with your own SSL configuration. You do not need `@SelfSignedCert` when providing your own certificates.
+
+**Q: Are self-signed certificates shared across test classes?**
+
+A: Yes. Certificates are generated once per JVM and stored in the root extension context. All test classes annotated
+with `@SelfSignedCert` share the same certificate artifacts. This avoids the overhead of running `keytool` for every
+test class.
 
 **Q: When are injected resources cleaned up?**
 

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -60,7 +60,29 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <!-- Required for the SslBootstrapTest -->
+                                <arg>--add-modules</arg>
+                                <arg>java.net.http</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-modules java.net.http</argLine>
+                </configuration>
                 <executions>
                     <execution>
                         <id>java11-test</id>

--- a/extension/src/main/java/dev/resteasy/junit/extension/annotations/RestBootstrap.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/annotations/RestBootstrap.java
@@ -14,6 +14,7 @@ import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication;
 import jakarta.ws.rs.core.Application;
 
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -155,4 +156,32 @@ public @interface RestBootstrap {
      * @return the timeout unit
      */
     TimeUnit timeoutUnit() default TimeUnit.SECONDS;
+
+    /**
+     * The SSL client authentication mode to use when the test class is also annotated with
+     * {@link SelfSignedCert @SelfSignedCert}.
+     * <p>
+     * This controls whether the server requests or requires a client certificate during the TLS handshake:
+     * </p>
+     * <ul>
+     * <li>{@link SSLClientAuthentication#OPTIONAL OPTIONAL} (default) — the server requests a client certificate
+     * but does not require one. This is the recommended default for testing, as the injected
+     * {@link jakarta.ws.rs.client.Client Client} is always configured with the client SSL context.</li>
+     * <li>{@link SSLClientAuthentication#MANDATORY MANDATORY} — the server requires a valid client certificate.
+     * Connections without a client certificate will be rejected.</li>
+     * <li>{@link SSLClientAuthentication#NONE NONE} — the server does not request a client certificate.</li>
+     * </ul>
+     * <p>
+     * This attribute is only used by the default {@link ConfigurationProvider}. Custom providers specified via
+     * {@link #configFactory()} are responsible for their own SSL client authentication configuration.
+     * </p>
+     * <p>
+     * This attribute has no effect if the test class is not annotated with {@link SelfSignedCert @SelfSignedCert}.
+     * </p>
+     *
+     * @return the SSL client authentication mode
+     *
+     * @see SelfSignedCert
+     */
+    SSLClientAuthentication sslClientAuthentication() default SSLClientAuthentication.OPTIONAL;
 }

--- a/extension/src/main/java/dev/resteasy/junit/extension/annotations/SelfSignedCert.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/annotations/SelfSignedCert.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import dev.resteasy.junit.extension.extensions.SelfSignedCertificateExtension;
+
+/**
+ * Enables generation of self-signed certificates for SSL/TLS testing.
+ * <p>
+ * When placed on a test class, this annotation triggers the generation of self-signed certificates for both
+ * server and client. The generated {@link dev.resteasy.junit.extension.api.SelfSignedCertificate SelfSignedCertificate}
+ * can be injected into test fields annotated with {@link SslCert @SslCert} or into test method parameters by type.
+ * </p>
+ *
+ * <h2>Standalone Usage</h2>
+ * <p>
+ * This annotation can be used independently of {@link RestBootstrap @RestBootstrap} when only the certificate
+ * artifacts are needed (e.g., for configuring a non-Jakarta REST client or an external server):
+ * </p>
+ *
+ * <pre>
+ * &#64;SelfSignedCert
+ * public class ClientTest {
+ *     &#64;SslCert
+ *     private SelfSignedCertificate certificate;
+ *
+ *     &#64;Test
+ *     public void testClient() {
+ *         SSLContext clientCtx = certificate.clientSslContext();
+ *         // configure a custom client with the SSL context
+ *     }
+ * }
+ * </pre>
+ *
+ * <h2>Usage with {@code @RestBootstrap}</h2>
+ * <p>
+ * When combined with {@link RestBootstrap @RestBootstrap}, the server is automatically started with HTTPS using
+ * the generated server SSL context, and injected {@link jakarta.ws.rs.client.Client Client} instances are
+ * configured with the client SSL context:
+ * </p>
+ *
+ * <pre>
+ * &#64;SelfSignedCert
+ * &#64;RestBootstrap(MyResource.class)
+ * public class SslTest {
+ *     &#64;RestResource
+ *     private Client client; // auto-configured with client SSL context
+ *
+ *     &#64;Test
+ *     public void testHttps(URI baseUri) {
+ *         assertEquals("https", baseUri.getScheme());
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>
+ * Tests annotated with this annotation are automatically tagged with {@code ssl-test}, allowing them to be
+ * included or excluded using JUnit {@link org.junit.jupiter.api.Tag tag filtering}.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ * @see SslCert
+ * @see dev.resteasy.junit.extension.api.SelfSignedCertificate
+ * @since 1.0.0
+ */
+@Inherited
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(SelfSignedCertificateExtension.class)
+@Tag("ssl-test")
+public @interface SelfSignedCert {
+}

--- a/extension/src/main/java/dev/resteasy/junit/extension/annotations/SslCert.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/annotations/SslCert.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a field for injection of a {@link dev.resteasy.junit.extension.api.SelfSignedCertificate SelfSignedCertificate}.
+ * <p>
+ * The test class must also be annotated with {@link SelfSignedCert @SelfSignedCert} to trigger certificate generation.
+ * </p>
+ *
+ * <pre>
+ * &#64;SelfSignedCert
+ * public class SslTest {
+ *     &#64;SslCert
+ *     private SelfSignedCertificate certificate;
+ *
+ *     &#64;Test
+ *     public void testSsl() {
+ *         SSLContext ctx = certificate.clientSslContext();
+ *         // ...
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>
+ * This annotation can also be used on fields in {@link dev.resteasy.junit.extension.api.ConfigurationProvider
+ * ConfigurationProvider} and {@link dev.resteasy.junit.extension.api.RestClientBuilderProvider
+ * RestClientBuilderProvider} implementations to receive the generated certificate for custom SSL configuration:
+ * </p>
+ *
+ * <pre>
+ * public class CustomSslConfigProvider implements ConfigurationProvider {
+ *     &#64;SslCert
+ *     private SelfSignedCertificate certificate;
+ *
+ *     &#64;Override
+ *     public Configuration getConfiguration(ExtensionContext context) {
+ *         return Configuration.builder()
+ *                 .protocol("HTTPS")
+ *                 .sslContext(certificate.serverSslContext())
+ *                 .build();
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>
+ * For test method parameters, injection is resolved by type without requiring this annotation.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ * @see SelfSignedCert
+ * @see dev.resteasy.junit.extension.api.SelfSignedCertificate
+ * @since 1.0.0
+ */
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SslCert {
+}

--- a/extension/src/main/java/dev/resteasy/junit/extension/annotations/package-info.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/annotations/package-info.java
@@ -18,6 +18,14 @@
  * injection of REST resources (Client, WebTarget, URI, etc.)</li>
  * </ul>
  *
+ * <h2>SSL Annotations</h2>
+ * <ul>
+ * <li>{@link dev.resteasy.junit.extension.annotations.SelfSignedCert @SelfSignedCert} - Generates self-signed
+ * certificates for SSL/TLS testing</li>
+ * <li>{@link dev.resteasy.junit.extension.annotations.SslCert @SslCert} - Marks fields for injection of the generated
+ * {@link dev.resteasy.junit.extension.api.SelfSignedCertificate SelfSignedCertificate}</li>
+ * </ul>
+ *
  * <h2>Qualifier Annotations</h2>
  * <ul>
  * <li>{@link dev.resteasy.junit.extension.annotations.RequestPath @RequestPath} - Qualifies WebTarget or URI injection

--- a/extension/src/main/java/dev/resteasy/junit/extension/api/ConfigurationProvider.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/api/ConfigurationProvider.java
@@ -53,6 +53,30 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * the global provider will be used automatically for all tests.
  * </p>
  *
+ * <h2>SSL Support</h2>
+ * <p>
+ * When the test class is annotated with
+ * {@link dev.resteasy.junit.extension.annotations.SelfSignedCert @SelfSignedCert}, implementations can receive the
+ * generated certificate by declaring a field annotated with
+ * {@link dev.resteasy.junit.extension.annotations.SslCert @SslCert}:
+ * </p>
+ *
+ * <pre>
+ * public class CustomSslConfigProvider implements ConfigurationProvider {
+ *     &#64;SslCert
+ *     private SelfSignedCertificate certificate;
+ *
+ *     &#64;Override
+ *     public Configuration getConfiguration(ExtensionContext context) {
+ *         return Configuration.builder()
+ *                 .port(9090)
+ *                 .protocol("HTTPS")
+ *                 .sslContext(certificate.serverSslContext())
+ *                 .build();
+ *     }
+ * }
+ * </pre>
+ *
  * <h2>Requirements</h2>
  * <ul>
  * <li>Must have a public no-argument constructor</li>

--- a/extension/src/main/java/dev/resteasy/junit/extension/api/RestClientBuilderProvider.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/api/RestClientBuilderProvider.java
@@ -55,6 +55,28 @@ import jakarta.ws.rs.client.ClientBuilder;
  * be used automatically for all injected Client instances.
  * </p>
  *
+ * <h2>SSL Support</h2>
+ * <p>
+ * When the test class is annotated with
+ * {@link dev.resteasy.junit.extension.annotations.SelfSignedCert @SelfSignedCert}, implementations can receive the
+ * generated certificate by declaring a field annotated with
+ * {@link dev.resteasy.junit.extension.annotations.SslCert @SslCert}:
+ * </p>
+ *
+ * <pre>
+ * public class CustomSslClientProvider implements RestClientBuilderProvider {
+ *     &#64;SslCert
+ *     private SelfSignedCertificate certificate;
+ *
+ *     &#64;Override
+ *     public ClientBuilder getClientBuilder() {
+ *         return ClientBuilder.newBuilder()
+ *                 .sslContext(certificate.clientSslContext())
+ *                 .connectTimeout(5, TimeUnit.SECONDS);
+ *     }
+ * }
+ * </pre>
+ *
  * <h2>Requirements</h2>
  * <ul>
  * <li>Must have a public no-argument constructor</li>

--- a/extension/src/main/java/dev/resteasy/junit/extension/api/SelfSignedCertificate.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/api/SelfSignedCertificate.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.api;
+
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.UUID;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * Provides access to self-signed certificate artifacts generated for SSL/TLS testing.
+ * <p>
+ * When a test class is annotated with
+ * {@link dev.resteasy.junit.extension.annotations.SelfSignedCert @SelfSignedCert}, the extension generates
+ * self-signed certificates for both server and client. This type can be injected into test fields annotated with
+ * {@link dev.resteasy.junit.extension.annotations.SslCert @SslCert} or into test method parameters by type.
+ * </p>
+ *
+ * <h2>Usage</h2>
+ *
+ * <pre>
+ * &#64;SelfSignedCert
+ * &#64;RestBootstrap(MyResource.class)
+ * public class SslTest {
+ *
+ *     &#64;SslCert
+ *     private SelfSignedCertificate certificate;
+ *
+ *     &#64;Test
+ *     public void testSsl() {
+ *         SSLContext clientCtx = certificate.clientSslContext();
+ *         // use the client SSL context to configure a non-Jakarta REST client
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>
+ * When combined with {@link dev.resteasy.junit.extension.annotations.RestBootstrap @RestBootstrap}, the server is
+ * automatically started with HTTPS and injected {@link jakarta.ws.rs.client.Client Client} instances are configured
+ * with the client {@link SSLContext}. In that case, direct access to this type is often not needed.
+ * </p>
+ * <p>
+ * This type is primarily useful when configuring non-Jakarta REST HTTP clients, when direct access to keystore files is
+ * required, or when using {@link dev.resteasy.junit.extension.annotations.SelfSignedCert @SelfSignedCert} standalone
+ * without {@link dev.resteasy.junit.extension.annotations.RestBootstrap @RestBootstrap}.
+ * </p>
+ * <p>
+ * For custom SSL configuration (e.g., using your own certificates), use a
+ * {@link ConfigurationProvider} for the server and a {@link RestClientBuilderProvider} for the client instead.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ * @see dev.resteasy.junit.extension.annotations.SelfSignedCert
+ * @see dev.resteasy.junit.extension.annotations.SslCert
+ * @since 1.0.0
+ */
+public interface SelfSignedCertificate {
+
+    /**
+     * The password used for all generated keystore and truststore files.
+     * <p>
+     * A random value is generated. This constant is provided for convenience when using APIs that require the
+     * password directly, such as
+     * {@link jakarta.ws.rs.client.ClientBuilder#keyStore(KeyStore, char[]) ClientBuilder.keyStore()}.
+     * </p>
+     */
+    String KEYSTORE_PASSWORD = UUID.randomUUID().toString();
+
+    /**
+     * Returns the {@link SSLContext} configured for the client.
+     * <p>
+     * This context is automatically applied to injected {@link jakarta.ws.rs.client.Client Client} instances when
+     * {@link dev.resteasy.junit.extension.annotations.SelfSignedCert @SelfSignedCert} is present on the test class
+     * alongside {@link dev.resteasy.junit.extension.annotations.RestBootstrap @RestBootstrap} and no custom
+     * {@link RestClientBuilderProvider} is specified via
+     * {@link dev.resteasy.junit.extension.annotations.RestClientConfig @RestClientConfig}. When a custom provider is
+     * used, it is responsible for configuring the client SSL context itself, typically via
+     * {@link dev.resteasy.junit.extension.annotations.SslCert @SslCert} field injection.
+     * </p>
+     *
+     * @return the client SSL context
+     */
+    SSLContext clientSslContext();
+
+    /**
+     * Returns the client {@link KeyStore} containing the client's private key and certificate.
+     * <p>
+     * This can be used directly with APIs that accept a {@link KeyStore}, such as
+     * {@link jakarta.ws.rs.client.ClientBuilder#keyStore(KeyStore, char[]) ClientBuilder.keyStore()}.
+     * </p>
+     *
+     * @return the client keystore
+     */
+    KeyStore clientKeyStore();
+
+    /**
+     * Returns the path to the client keystore file containing the client's private key and certificate.
+     *
+     * @return the path to the client keystore file
+     */
+    Path clientKeyStorePath();
+
+    /**
+     * Returns the client {@link KeyStore truststore} containing the server's certificate.
+     * <p>
+     * This can be used directly with APIs that accept a {@link KeyStore}, such as
+     * {@link jakarta.ws.rs.client.ClientBuilder#trustStore(KeyStore) ClientBuilder.trustStore()}.
+     * </p>
+     *
+     * @return the client truststore
+     */
+    KeyStore clientTrustStore();
+
+    /**
+     * Returns the path to the client truststore file containing the server's certificate.
+     *
+     * @return the path to the client truststore file
+     */
+    Path clientTrustStorePath();
+
+    /**
+     * Returns the {@link SSLContext} configured for the server.
+     * <p>
+     * This context is automatically applied to the {@link jakarta.ws.rs.SeBootstrap.Configuration SeBootstrap
+     * Configuration} when {@link dev.resteasy.junit.extension.annotations.SelfSignedCert @SelfSignedCert} is present
+     * on the test class alongside {@link dev.resteasy.junit.extension.annotations.RestBootstrap @RestBootstrap} and no
+     * custom {@link ConfigurationProvider} is specified via
+     * {@link dev.resteasy.junit.extension.annotations.RestBootstrap#configFactory() configFactory}. When a custom
+     * provider is used, it is responsible for configuring the server SSL context itself, typically via
+     * {@link dev.resteasy.junit.extension.annotations.SslCert @SslCert} field injection.
+     * </p>
+     *
+     * @return the server SSL context
+     */
+    SSLContext serverSslContext();
+
+    /**
+     * Returns the server {@link KeyStore} containing the server's private key and certificate.
+     * <p>
+     * This can be used directly with APIs that accept a {@link KeyStore}, such as
+     * {@link jakarta.ws.rs.client.ClientBuilder#keyStore(KeyStore, char[]) ClientBuilder.keyStore()}.
+     * </p>
+     *
+     * @return the server keystore
+     */
+    KeyStore serverKeyStore();
+
+    /**
+     * Returns the path to the server keystore file containing the server's private key and certificate.
+     *
+     * @return the path to the server keystore file
+     */
+    Path serverKeyStorePath();
+
+    /**
+     * Returns the server {@link KeyStore truststore} containing the client's certificate.
+     * <p>
+     * This can be used directly with APIs that accept a {@link KeyStore}, such as
+     * {@link jakarta.ws.rs.client.ClientBuilder#trustStore(KeyStore) ClientBuilder.trustStore()}.
+     * </p>
+     *
+     * @return the server truststore
+     */
+    KeyStore serverTrustStore();
+
+    /**
+     * Returns the path to the server truststore file containing the client's certificate.
+     *
+     * @return the path to the server truststore file
+     */
+    Path serverTrustStorePath();
+
+    /**
+     * Returns the password used for all keystore and truststore files.
+     *
+     * @return the keystore password
+     */
+    String keyStorePassword();
+
+    /**
+     * Returns the keystore type used for all generated keystore and truststore files.
+     *
+     * @return the keystore type (e.g., {@code "PKCS12"})
+     */
+    String keyStoreType();
+}

--- a/extension/src/main/java/dev/resteasy/junit/extension/api/package-info.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/api/package-info.java
@@ -10,6 +10,12 @@
  * extension through Service Provider Interfaces (SPI).
  * </p>
  *
+ * <h2>Types</h2>
+ * <ul>
+ * <li>{@link dev.resteasy.junit.extension.api.SelfSignedCertificate SelfSignedCertificate} - Provides access to
+ * generated self-signed certificate artifacts for SSL/TLS testing</li>
+ * </ul>
+ *
  * <h2>SPI Interfaces</h2>
  * <ul>
  * <li>{@link dev.resteasy.junit.extension.api.ConfigurationProvider ConfigurationProvider} - Provides custom

--- a/extension/src/main/java/dev/resteasy/junit/extension/extensions/DefaultConfigurationProvider.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/extensions/DefaultConfigurationProvider.java
@@ -6,17 +6,28 @@
 package dev.resteasy.junit.extension.extensions;
 
 import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import dev.resteasy.junit.extension.api.ConfigurationProvider;
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
 
 /**
  * Default implementation for the configuration provider.
  *
  * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
  */
-public class DefaultConfigurationProvider implements ConfigurationProvider {
+class DefaultConfigurationProvider implements ConfigurationProvider {
+    private final SelfSignedCertificate certificate;
+    private final SSLClientAuthentication sslClientAuthentication;
+
+    DefaultConfigurationProvider(final SelfSignedCertificate certificate,
+            final SSLClientAuthentication sslClientAuthentication) {
+        this.certificate = certificate;
+        this.sslClientAuthentication = sslClientAuthentication;
+    }
+
     @Override
     public SeBootstrap.Configuration getConfiguration(final ExtensionContext context) {
         final SeBootstrap.Configuration.Builder builder = SeBootstrap.Configuration.builder();
@@ -25,6 +36,11 @@ public class DefaultConfigurationProvider implements ConfigurationProvider {
         context.getConfigurationParameter("dev.resteasy.junit.extension.port", Integer::parseInt)
                 .ifPresent(builder::port);
         context.getConfigurationParameter("dev.resteasy.junit.extension.root-path").ifPresent(builder::rootPath);
+        if (certificate != null) {
+            builder.sslContext(certificate.serverSslContext());
+            builder.protocol("https");
+            builder.sslClientAuthentication(sslClientAuthentication);
+        }
         return builder.build();
     }
 }

--- a/extension/src/main/java/dev/resteasy/junit/extension/extensions/DefaultSelfSignedCertificate.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/extensions/DefaultSelfSignedCertificate.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.extensions;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.JUnitException;
+
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
+
+/**
+ * Default implementation of {@link SelfSignedCertificate} that generates self-signed certificates using the JDK
+ * {@code keytool} command.
+ * <p>
+ * Instances are created via the {@link #getOrCreate(ExtensionContext)} factory method, which generates server and
+ * client key pairs, cross-signs them into truststores, and builds {@link SSLContext} instances for both sides. All
+ * generated files are stored in a temporary directory and cleaned up when {@link #close()} is called.
+ * </p>
+ * <p>
+ * This class is not intended for direct use by test authors. It is managed by the extension framework and
+ * accessible through the {@link SelfSignedCertificate} interface via
+ * {@link dev.resteasy.junit.extension.annotations.SslCert @SslCert} injection.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+class DefaultSelfSignedCertificate implements SelfSignedCertificate, AutoCloseable {
+    private static final Logger LOGGER = Logger.getLogger(DefaultSelfSignedCertificate.class);
+    private static final String KEY = "SelfSignedCertificate";
+
+    private static final String ALIAS = "self-signed";
+    private static final String CLIENT_DN = "CN=localhost, OU=Test, L=Test, ST=Test, C=Test";
+    private static final String SERVER_DN = "CN=localhost, OU=Unknown, L=Unknown, ST=Unknown, C=Unknown";
+    private static final String KEYSTORE_TYPE = "PKCS12";
+
+    private final Path tempDir;
+    private final SslContextHolder serverHolder;
+    private final SslContextHolder clientHolder;
+
+    private DefaultSelfSignedCertificate(final Path tempDir, final SslContextHolder serverHolder,
+            final SslContextHolder clientHolder) {
+        this.tempDir = tempDir;
+        this.serverHolder = serverHolder;
+        this.clientHolder = clientHolder;
+    }
+
+    /**
+     * Gets the current {@link DefaultSelfSignedCertificate}.
+     *
+     * @return a certificate holder
+     *
+     */
+    static DefaultSelfSignedCertificate get(final ExtensionContext context) {
+        return getStore(context).get(KEY, DefaultSelfSignedCertificate.class);
+    }
+
+    /**
+     * Creates or gets a {@link DefaultSelfSignedCertificate from the context provided. If creating a new cert is
+     * required, the {@code keytool} command is used to generate a self-signed certificate for both the server and the
+     * client.
+     * <p>
+     * On failure, any partially created files and the temporary directory are cleaned up before the exception is
+     * propagated.
+     * </p>
+     *
+     * @return a fully initialized certificate holder
+     *
+     */
+    static DefaultSelfSignedCertificate getOrCreate(final ExtensionContext context) {
+        final ExtensionContext.Store store = getStore(context);
+        return store.getOrComputeIfAbsent(KEY, CertFunction.INSTANCE, DefaultSelfSignedCertificate.class);
+    }
+
+    @Override
+    public SSLContext clientSslContext() {
+        return clientHolder.sslContext;
+    }
+
+    @Override
+    public KeyStore clientKeyStore() {
+        return clientHolder.keyStore;
+    }
+
+    @Override
+    public Path clientKeyStorePath() {
+        return clientHolder.keyStoreFile;
+    }
+
+    @Override
+    public KeyStore clientTrustStore() {
+        return clientHolder.trustStore;
+    }
+
+    @Override
+    public Path clientTrustStorePath() {
+        return clientHolder.trustStoreFile;
+    }
+
+    @Override
+    public SSLContext serverSslContext() {
+        return serverHolder.sslContext;
+    }
+
+    @Override
+    public KeyStore serverKeyStore() {
+        return serverHolder.keyStore;
+    }
+
+    @Override
+    public Path serverKeyStorePath() {
+        return serverHolder.keyStoreFile;
+    }
+
+    @Override
+    public KeyStore serverTrustStore() {
+        return serverHolder.trustStore;
+    }
+
+    @Override
+    public Path serverTrustStorePath() {
+        return serverHolder.trustStoreFile;
+    }
+
+    @Override
+    public String keyStorePassword() {
+        return KEYSTORE_PASSWORD;
+    }
+
+    @Override
+    public String keyStoreType() {
+        return KEYSTORE_TYPE;
+    }
+
+    @Override
+    public void close() {
+        deleteRecursively(tempDir);
+    }
+
+    private static SslContextHolder createSslContext(final Path keyStoreFile, final Path trustStoreFile) throws Exception {
+        final KeyStore keyStore = loadKeyStore(keyStoreFile);
+        final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(keyStore, KEYSTORE_PASSWORD.toCharArray());
+
+        final KeyStore trustStore = loadKeyStore(trustStoreFile);
+        final TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustStore);
+
+        final SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        return new SslContextHolder(sslContext, keyStore, keyStoreFile, trustStore, trustStoreFile);
+    }
+
+    private static KeyStore loadKeyStore(final Path file) throws Exception {
+        final KeyStore ks = KeyStore.getInstance(KEYSTORE_TYPE);
+        try (InputStream in = Files.newInputStream(file)) {
+            ks.load(in, KEYSTORE_PASSWORD.toCharArray());
+        }
+        return ks;
+    }
+
+    private static void keytool(final ForkJoinPool executor, final String... args) throws Exception {
+        final String keytoolCmd = Path.of(System.getProperty("java.home"), "bin", "keytool").toString();
+        final List<String> command = new ArrayList<>(args.length + 1);
+        command.add(keytoolCmd);
+        command.addAll(List.of(args));
+        final Process process = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start();
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            final Runnable consoleConsumer = () -> {
+                final byte[] buffer = new byte[256];
+                int len;
+                try (InputStream in = process.getInputStream()) {
+                    while ((len = in.read(buffer)) != -1) {
+                        output.write(buffer, 0, len);
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            };
+            final ForkJoinTask<?> task = executor.submit(consoleConsumer);
+            if (!process.waitFor(30, TimeUnit.SECONDS)) {
+                task.cancel(true);
+                process.destroyForcibly();
+                throw new JUnitException(String.format("keytool did not exit within 30 seconds: %s", output));
+            }
+            final int exitCode = process.exitValue();
+            if (exitCode != 0) {
+                task.join();
+                throw new IOException(String.format("keytool failed with exit code %d: %s", exitCode, output));
+            }
+        }
+    }
+
+    private static void deleteRecursively(final Path dir) {
+        if (!Files.exists(dir)) {
+            return;
+        }
+        try {
+            Files.walkFileTree(dir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) {
+                    safeDelete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) {
+                    safeDelete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            LOGGER.debugf(e, "Failed to recursively delete directory %s", dir);
+        }
+    }
+
+    private static void safeDelete(final Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            LOGGER.debugf(e, "Failed to delete file %s", path);
+        }
+    }
+
+    private static ExtensionContext.Store getStore(final ExtensionContext context) {
+        return context.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
+    }
+
+    private static class SslContextHolder {
+        final SSLContext sslContext;
+        final KeyStore keyStore;
+        final Path keyStoreFile;
+        final KeyStore trustStore;
+        final Path trustStoreFile;
+
+        SslContextHolder(final SSLContext sslContext, final KeyStore keyStore, final Path keyStoreFile,
+                final KeyStore trustStore, final Path trustStoreFile) {
+            this.sslContext = sslContext;
+            this.keyStore = keyStore;
+            this.keyStoreFile = keyStoreFile;
+            this.trustStore = trustStore;
+            this.trustStoreFile = trustStoreFile;
+        }
+    }
+
+    private static class CertFunction implements Function<String, DefaultSelfSignedCertificate> {
+        static final CertFunction INSTANCE = new CertFunction();
+
+        @Override
+        public DefaultSelfSignedCertificate apply(final String s) {
+            @SuppressWarnings("resource")
+            final ForkJoinPool executor = ForkJoinPool.commonPool();
+            try {
+                final Path tempDir = Files.createTempDirectory("resteasy-ssl-");
+
+                final Path serverKeyStoreFile = tempDir.resolve("server.keystore");
+                final Path serverTrustStoreFile = tempDir.resolve("server.truststore");
+                final Path clientKeyStoreFile = tempDir.resolve("client.keystore");
+                final Path clientTrustStoreFile = tempDir.resolve("client.truststore");
+
+                final Path serverCertFile = tempDir.resolve("server.cer");
+                final Path clientCertFile = tempDir.resolve("client.cer");
+
+                try {
+                    // Generate server key pair and export its certificate
+                    keytool(executor, "-genkeypair", "-alias", ALIAS,
+                            "-keyalg", "RSA", "-keysize", "2048",
+                            "-storetype", KEYSTORE_TYPE,
+                            "-keystore", serverKeyStoreFile.toString(),
+                            "-storepass", KEYSTORE_PASSWORD,
+                            "-dname", SERVER_DN);
+                    keytool(executor, "-exportcert", "-alias", ALIAS,
+                            "-keystore", serverKeyStoreFile.toString(),
+                            "-storepass", KEYSTORE_PASSWORD,
+                            "-file", serverCertFile.toString());
+
+                    // Generate client key pair and export its certificate
+                    keytool(executor, "-genkeypair", "-alias", ALIAS,
+                            "-keyalg", "RSA", "-keysize", "2048",
+                            "-storetype", KEYSTORE_TYPE,
+                            "-keystore", clientKeyStoreFile.toString(),
+                            "-storepass", KEYSTORE_PASSWORD,
+                            "-dname", CLIENT_DN);
+                    keytool(executor, "-exportcert", "-alias", ALIAS,
+                            "-keystore", clientKeyStoreFile.toString(),
+                            "-storepass", KEYSTORE_PASSWORD,
+                            "-file", clientCertFile.toString());
+
+                    // Import server cert into client truststore (so client trusts server)
+                    keytool(executor, "-importcert", "-alias", "server",
+                            "-storetype", KEYSTORE_TYPE,
+                            "-keystore", clientTrustStoreFile.toString(),
+                            "-storepass", KEYSTORE_PASSWORD,
+                            "-file", serverCertFile.toString(),
+                            "-noprompt");
+
+                    // Import client cert into server truststore (so server trusts client)
+                    keytool(executor, "-importcert", "-alias", "client",
+                            "-storetype", KEYSTORE_TYPE,
+                            "-keystore", serverTrustStoreFile.toString(),
+                            "-storepass", KEYSTORE_PASSWORD,
+                            "-file", clientCertFile.toString(),
+                            "-noprompt");
+                    final SslContextHolder server = createSslContext(serverKeyStoreFile, serverTrustStoreFile);
+                    final SslContextHolder client = createSslContext(clientKeyStoreFile, clientTrustStoreFile);
+                    return new DefaultSelfSignedCertificate(tempDir, server, client);
+                } catch (Exception e) {
+                    deleteRecursively(tempDir);
+                    if (e instanceof IOException) {
+                        throw (IOException) e;
+                    }
+                    if (e instanceof JUnitException) {
+                        throw (JUnitException) e;
+                    }
+                    throw new JUnitException("Failed to generate SSL contexts", e);
+                } finally {
+                    try {
+                        Files.deleteIfExists(serverCertFile);
+                    } catch (Exception e) {
+                        LOGGER.warnf(e, "Could not delete server certificate file %s", serverCertFile);
+                    }
+                    try {
+                        Files.deleteIfExists(clientCertFile);
+                    } catch (Exception e) {
+                        LOGGER.warnf(e, "Could not delete client certificate file %s", clientCertFile);
+                    }
+                }
+            } catch (IOException e) {
+                throw new JUnitException("Failed to generate SSL contexts", e);
+            }
+        }
+    }
+}

--- a/extension/src/main/java/dev/resteasy/junit/extension/extensions/InstanceManager.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/extensions/InstanceManager.java
@@ -34,6 +34,7 @@ import dev.resteasy.junit.extension.annotations.RestBootstrap;
 import dev.resteasy.junit.extension.annotations.RestClientConfig;
 import dev.resteasy.junit.extension.api.ConfigurationProvider;
 import dev.resteasy.junit.extension.api.RestClientBuilderProvider;
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -45,11 +46,13 @@ class InstanceManager implements ExtensionContext.Store.CloseableResource, AutoC
     private final ReadWriteLock lock;
     private final Class<?> testClass;
     private final RestBootstrap bootstrap;
+    private final SelfSignedCertificate certificate;
     private BootstrapHolder holder;
 
-    public InstanceManager(final Class<?> testClass, final RestBootstrap bootstrap) {
+    public InstanceManager(final Class<?> testClass, final RestBootstrap bootstrap, final SelfSignedCertificate certificate) {
         this.testClass = testClass;
         this.bootstrap = bootstrap;
+        this.certificate = certificate;
         lock = new ReentrantReadWriteLock();
     }
 
@@ -65,9 +68,9 @@ class InstanceManager implements ExtensionContext.Store.CloseableResource, AutoC
     }
 
     static InstanceManager getOrCreateInstance(final ExtensionContext context, final Class<?> testClass,
-            final RestBootstrap bootstrap) {
+            final RestBootstrap bootstrap, final SelfSignedCertificate certificate) {
         final var store = ClassContext.getStore(context);
-        return store.getOrComputeIfAbsent(MANGER_KEY, key -> new InstanceManager(testClass, bootstrap),
+        return store.getOrComputeIfAbsent(MANGER_KEY, key -> new InstanceManager(testClass, bootstrap, certificate),
                 InstanceManager.class);
     }
 
@@ -94,10 +97,17 @@ class InstanceManager implements ExtensionContext.Store.CloseableResource, AutoC
         }
         lock.writeLock().lock();
         try {
+            if (holder != null) {
+                return;
+            }
             holder = new BootstrapHolder();
             final Class<? extends ConfigurationProvider> factoryType = bootstrap.configFactory();
             final ConfigurationProvider factory = createProvider(factoryType, ConfigurationProvider.class,
-                    DefaultConfigurationProvider::new);
+                    () -> new DefaultConfigurationProvider(certificate, bootstrap.sslClientAuthentication()));
+            // Inject any SelfSignedCertificate annotated fields
+            if (certificate != null) {
+                SelfSignedCertificateExtension.injectInstanceFields(factory, certificate);
+            }
             final SeBootstrap.Configuration configuration = factory.getConfiguration(context);
             final CompletionStage<SeBootstrap.Instance> stage;
             if (bootstrap.application() == Application.class) {
@@ -176,14 +186,19 @@ class InstanceManager implements ExtensionContext.Store.CloseableResource, AutoC
     }
 
     private Client createClient(final RestClientConfig restClientConfig) {
+        final Supplier<RestClientBuilderProvider> defaultProvider = () -> new DefaultRestClientBuilderProvider(certificate);
+        final RestClientBuilderProvider provider;
         if (restClientConfig == null) {
-            return loadProvider(RestClientBuilderProvider.class, () -> ClientBuilder::newBuilder).getClientBuilder()
-                    .build();
+            provider = loadProvider(RestClientBuilderProvider.class, defaultProvider);
+        } else {
+            final Class<? extends RestClientBuilderProvider> factoryType = restClientConfig.value();
+            provider = createProvider(factoryType, RestClientBuilderProvider.class, defaultProvider);
         }
-        final var factoryType = restClientConfig.value();
-        final var factory = createProvider(factoryType, RestClientBuilderProvider.class,
-                () -> ClientBuilder::newBuilder);
-        final var builder = factory.getClientBuilder();
+        // Inject any SelfSignedCertificate annotated fields
+        if (certificate != null) {
+            SelfSignedCertificateExtension.injectInstanceFields(provider, certificate);
+        }
+        final ClientBuilder builder = provider.getClientBuilder();
         return builder.build();
     }
 
@@ -243,6 +258,23 @@ class InstanceManager implements ExtensionContext.Store.CloseableResource, AutoC
                     }
                 }
             }
+        }
+    }
+
+    private static class DefaultRestClientBuilderProvider implements RestClientBuilderProvider {
+        private final SelfSignedCertificate certificate;
+
+        private DefaultRestClientBuilderProvider(final SelfSignedCertificate certificate) {
+            this.certificate = certificate;
+        }
+
+        @Override
+        public ClientBuilder getClientBuilder() {
+            final ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+            if (certificate != null) {
+                clientBuilder.sslContext(certificate.clientSslContext());
+            }
+            return clientBuilder;
         }
     }
 }

--- a/extension/src/main/java/dev/resteasy/junit/extension/extensions/SeBootstrapExtension.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/extensions/SeBootstrapExtension.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 import dev.resteasy.junit.extension.annotations.RestBootstrap;
+import dev.resteasy.junit.extension.annotations.SelfSignedCert;
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -37,6 +39,11 @@ public class SeBootstrapExtension implements BeforeAllCallback {
         if (restBootstrap.application() != Application.class && restBootstrap.value().length > 0) {
             throw new ExtensionConfigurationException("Only the value() or application() is allowed to be defined.");
         }
-        InstanceManager.getOrCreateInstance(context, testClass, restBootstrap).startInstance(context);
+        final Optional<SelfSignedCert> selfSignedCert = AnnotationSupport.findAnnotation(testClass, SelfSignedCert.class);
+        SelfSignedCertificate certificate = null;
+        if (selfSignedCert.isPresent()) {
+            certificate = DefaultSelfSignedCertificate.getOrCreate(context);
+        }
+        InstanceManager.getOrCreateInstance(context, testClass, restBootstrap, certificate).startInstance(context);
     }
 }

--- a/extension/src/main/java/dev/resteasy/junit/extension/extensions/SelfSignedCertificateExtension.java
+++ b/extension/src/main/java/dev/resteasy/junit/extension/extensions/SelfSignedCertificateExtension.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.extensions;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import dev.resteasy.junit.extension.annotations.SelfSignedCert;
+import dev.resteasy.junit.extension.annotations.SslCert;
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
+
+/**
+ * An extension used to generate self-signed certificates at runtime and inject them into tests.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ * @see SelfSignedCertificate
+ * @see SelfSignedCert
+ * @see SslCert
+ */
+public class SelfSignedCertificateExtension implements BeforeAllCallback, BeforeEachCallback, ParameterResolver {
+
+    @Override
+    public void beforeAll(final ExtensionContext context) {
+        final Class<?> testClass = context.getRequiredTestClass();
+        final Optional<SelfSignedCert> selfSignedCert = AnnotationSupport.findAnnotation(testClass, SelfSignedCert.class);
+        if (selfSignedCert.isEmpty()) {
+            return;
+        }
+
+        final SelfSignedCertificate cert = DefaultSelfSignedCertificate.getOrCreate(context);
+        injectStaticFields(testClass, cert);
+    }
+
+    @Override
+    public void beforeEach(final ExtensionContext context) {
+        final SelfSignedCertificate cert = DefaultSelfSignedCertificate.get(context);
+        // Do not process the fields if the cert is null
+        if (cert != null) {
+            context.getRequiredTestInstances().getAllInstances()
+                    .forEach(instance -> injectInstanceFields(instance, cert));
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return SelfSignedCertificate.class.isAssignableFrom(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        if (SelfSignedCertificate.class.isAssignableFrom(parameterContext.getParameter().getType())) {
+            return DefaultSelfSignedCertificate.get(extensionContext);
+        }
+        throw new ParameterResolutionException(String.format("Type %s is not assignable to %s",
+                parameterContext.getParameter().getType().getName(), SelfSignedCertificate.class.getName()));
+    }
+
+    static void injectInstanceFields(final Object instance, final SelfSignedCertificate value) {
+        injectFields(instance, instance.getClass(), (f) -> !Modifier.isStatic(f.getModifiers()), value);
+    }
+
+    private static void injectStaticFields(final Class<?> testClass, final SelfSignedCertificate value) {
+        injectFields(null, testClass, (f) -> Modifier.isStatic(f.getModifiers()), value);
+    }
+
+    private static void injectFields(final Object testInstance, final Class<?> testClass,
+            final Predicate<Field> predicate, final SelfSignedCertificate value) {
+
+        AnnotationSupport.findAnnotatedFields(testClass, SslCert.class, predicate).forEach(field -> {
+            if (!SelfSignedCertificate.class.isAssignableFrom(field.getType())) {
+                throw new ExtensionConfigurationException(
+                        String.format("Field '%s' is not of type %s", field, SelfSignedCertificate.class.getName()));
+            }
+            if (Modifier.isFinal(field.getModifiers())) {
+                throw new ExtensionConfigurationException(
+                        String.format("Field '%s' cannot be final for injecting a SslCert resource.", field));
+            }
+            try {
+                if (field.trySetAccessible()) {
+                    field.set(testInstance, value);
+                } else {
+                    throw new ExtensionConfigurationException(
+                            String.format("Could not make field %s accessible for injection.", field));
+                }
+            } catch (Exception e) {
+                if (e instanceof ExtensionConfigurationException) {
+                    throw (ExtensionConfigurationException) e;
+                }
+                throw new ExtensionConfigurationException(
+                        String.format("Could not make field %s accessible for injection.", field), e);
+            }
+        });
+    }
+}

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/NoSslRegressionTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/NoSslRegressionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.extension;
+
+import java.net.URI;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import dev.resteasy.junit.extension.annotations.RestBootstrap;
+import dev.resteasy.junit.extension.annotations.RestResource;
+import dev.resteasy.junit.extension.extension.resources.EchoResource;
+
+/**
+ * Regression test verifying that {@link RestBootstrap @RestBootstrap} without {@link
+ * dev.resteasy.junit.extension.annotations.SelfSignedCert @SelfSignedCert} still works over plain HTTP.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@RestBootstrap(EchoResource.class)
+public class NoSslRegressionTest {
+
+    @RestResource
+    private Client client;
+
+    @RestResource
+    private URI baseUri;
+
+    @Test
+    public void serverUsesHttp() {
+        Assertions.assertEquals("http", baseUri.getScheme(),
+                "Server should use HTTP when @SelfSignedCert is not present");
+    }
+
+    @Test
+    public void clientWorksOverHttp() {
+        final String result = client.target(baseUri)
+                .path("/echo")
+                .request()
+                .post(Entity.text("No SSL"), String.class);
+        Assertions.assertEquals("No SSL", result);
+    }
+}

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/SelfSignedCertStandaloneTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/SelfSignedCertStandaloneTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.extension;
+
+import java.nio.file.Files;
+
+import javax.net.ssl.SSLContext;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import dev.resteasy.junit.extension.annotations.SelfSignedCert;
+import dev.resteasy.junit.extension.annotations.SslCert;
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
+
+/**
+ * Tests {@link SelfSignedCert @SelfSignedCert} standalone without {@link
+ * dev.resteasy.junit.extension.annotations.RestBootstrap @RestBootstrap}.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@SelfSignedCert
+public class SelfSignedCertStandaloneTest {
+
+    @SslCert
+    private static SelfSignedCertificate STATIC_CERT;
+
+    @SslCert
+    private SelfSignedCertificate instanceCert;
+
+    @Test
+    public void staticFieldInjected() {
+        Assertions.assertNotNull(STATIC_CERT, "Static @SslCert field should be injected");
+    }
+
+    @Test
+    public void instanceFieldInjected() {
+        Assertions.assertNotNull(instanceCert, "Instance @SslCert field should be injected");
+    }
+
+    @Test
+    public void parameterInjected(final SelfSignedCertificate cert) {
+        Assertions.assertNotNull(cert, "Method parameter should be injected by type");
+    }
+
+    @Test
+    public void sameInstance(final SelfSignedCertificate cert) {
+        Assertions.assertSame(STATIC_CERT, instanceCert,
+                "Static and instance fields should be the same instance");
+        Assertions.assertSame(STATIC_CERT, cert,
+                "Static field and parameter should be the same instance");
+    }
+
+    @Test
+    public void serverSslContext() {
+        final SSLContext ctx = STATIC_CERT.serverSslContext();
+        Assertions.assertNotNull(ctx, "Server SSLContext should not be null");
+        Assertions.assertEquals("TLS", ctx.getProtocol(), "Server SSLContext protocol should be TLS");
+    }
+
+    @Test
+    public void clientSslContext() {
+        final SSLContext ctx = STATIC_CERT.clientSslContext();
+        Assertions.assertNotNull(ctx, "Client SSLContext should not be null");
+        Assertions.assertEquals("TLS", ctx.getProtocol(), "Client SSLContext protocol should be TLS");
+    }
+
+    @Test
+    public void keystoreObjectsExist() {
+        Assertions.assertNotNull(STATIC_CERT.serverKeyStore(), "Server keystore should not be null");
+        Assertions.assertNotNull(STATIC_CERT.serverTrustStore(), "Server truststore should not be null");
+        Assertions.assertNotNull(STATIC_CERT.clientKeyStore(), "Client keystore should not be null");
+        Assertions.assertNotNull(STATIC_CERT.clientTrustStore(), "Client truststore should not be null");
+    }
+
+    @Test
+    public void keystoreFilesExist() {
+        Assertions.assertTrue(Files.exists(STATIC_CERT.serverKeyStorePath()),
+                "Server keystore file should exist");
+        Assertions.assertTrue(Files.exists(STATIC_CERT.serverTrustStorePath()),
+                "Server truststore file should exist");
+        Assertions.assertTrue(Files.exists(STATIC_CERT.clientKeyStorePath()),
+                "Client keystore file should exist");
+        Assertions.assertTrue(Files.exists(STATIC_CERT.clientTrustStorePath()),
+                "Client truststore file should exist");
+    }
+
+    @Test
+    public void keystorePassword() {
+        Assertions.assertNotNull(STATIC_CERT.keyStorePassword(), "Keystore password should not be null");
+        Assertions.assertFalse(STATIC_CERT.keyStorePassword().isEmpty(), "Keystore password should not be empty");
+    }
+
+    @Test
+    public void keystoreType() {
+        Assertions.assertEquals("PKCS12", STATIC_CERT.keyStoreType(), "Keystore type should be PKCS12");
+    }
+
+    @Nested
+    class NestedInherited {
+
+        @SslCert
+        private SelfSignedCertificate nestedCert;
+
+        @Test
+        public void nestedFieldInjected() {
+            Assertions.assertNotNull(nestedCert, "Nested @SslCert field should be injected");
+        }
+
+        @Test
+        public void nestedSharesParentCert() {
+            Assertions.assertSame(STATIC_CERT, nestedCert,
+                    "Nested class should share parent's certificate (annotation is @Inherited)");
+        }
+
+        @Test
+        public void nestedParameterInjected(final SelfSignedCertificate cert) {
+            Assertions.assertNotNull(cert, "Nested method parameter should be injected by type");
+            Assertions.assertSame(cert, nestedCert,
+                    "Nested parameter should be the same instance as the nestedCert");
+            Assertions.assertSame(STATIC_CERT, cert,
+                    "Nested parameter should be the same instance as parent's static field");
+        }
+    }
+}

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/SslBootstrapTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/SslBootstrapTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.extension;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import dev.resteasy.junit.extension.annotations.RequestPath;
+import dev.resteasy.junit.extension.annotations.RestBootstrap;
+import dev.resteasy.junit.extension.annotations.RestResource;
+import dev.resteasy.junit.extension.annotations.SelfSignedCert;
+import dev.resteasy.junit.extension.annotations.SslCert;
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
+import dev.resteasy.junit.extension.extension.resources.RequestInfoResource;
+
+/**
+ * Tests {@link SelfSignedCert @SelfSignedCert} combined with {@link RestBootstrap @RestBootstrap}.
+ * Verifies the server starts on HTTPS and the injected client is configured with the client SSL context.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@RestBootstrap(RequestInfoResource.class)
+@SelfSignedCert
+public class SslBootstrapTest {
+
+    @SslCert
+    private SelfSignedCertificate certificate;
+
+    @RestResource
+    private Client client;
+
+    @RestResource
+    private URI baseUri;
+
+    @Test
+    public void serverUsesHttps() {
+        Assertions.assertEquals("https", baseUri.getScheme(),
+                "Server should be running on HTTPS when @SelfSignedCert is present");
+    }
+
+    @Test
+    public void injectedClientWorksOverHttps() {
+        final String result = client.target(baseUri)
+                .path("/info/request-uri")
+                .request()
+                .get(String.class);
+        Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+    }
+
+    @Test
+    public void checkClientSslContext(@RestResource @RequestPath("/info/request-uri") final URI uri) throws Exception {
+        final HttpClient httpClient = HttpClient.newBuilder()
+                .sslContext(certificate.clientSslContext())
+                .build();
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(uri)
+                .GET()
+                .build();
+        final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        Assertions.assertEquals(200, response.statusCode());
+        Assertions.assertEquals("https://localhost:8081/info/request-uri", response.body());
+    }
+
+    @Test
+    public void checkRestClientBuilder(@RestResource @RequestPath("/info/request-uri") final URI uri) {
+        try (Client client = ClientBuilder.newBuilder()
+                .keyStore(certificate.clientKeyStore(), SelfSignedCertificate.KEYSTORE_PASSWORD)
+                .trustStore(certificate.clientTrustStore())
+                .build()) {
+            final String result = client.target(uri)
+                    .request()
+                    .get(String.class);
+            Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+        }
+    }
+
+    @Test
+    public void checkRestClientBuilderSslContext(@RestResource @RequestPath("/info/request-uri") final URI uri) {
+        try (Client client = ClientBuilder.newBuilder().sslContext(certificate.clientSslContext()).build()) {
+            final String result = client.target(uri)
+                    .request()
+                    .get(String.class);
+            Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+        }
+    }
+
+    @Test
+    public void injectedWebTargetWorksOverHttps(@RestResource @RequestPath("/info/request-uri") final WebTarget target) {
+        final String result = target.request()
+                .get(String.class);
+        Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+    }
+
+    @Test
+    public void certificateIsAvailable() {
+        Assertions.assertNotNull(certificate, "Certificate should be injected");
+        Assertions.assertNotNull(certificate.serverSslContext(), "Server SSLContext should not be null");
+        Assertions.assertNotNull(certificate.clientSslContext(), "Client SSLContext should not be null");
+    }
+}

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/SslClientAuthenticationTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/SslClientAuthenticationTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.extension;
+
+import java.net.URI;
+
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import dev.resteasy.junit.extension.annotations.RequestPath;
+import dev.resteasy.junit.extension.annotations.RestBootstrap;
+import dev.resteasy.junit.extension.annotations.RestResource;
+import dev.resteasy.junit.extension.annotations.SelfSignedCert;
+import dev.resteasy.junit.extension.annotations.SslCert;
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
+import dev.resteasy.junit.extension.extension.resources.RequestInfoResource;
+
+/**
+ * Tests the {@link RestBootstrap#sslClientAuthentication()} attribute with different values.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+public class SslClientAuthenticationTest {
+
+    @Nested
+    @SelfSignedCert
+    @RestBootstrap(value = RequestInfoResource.class, sslClientAuthentication = SSLClientAuthentication.OPTIONAL)
+    class OptionalClientAuth {
+
+        @SslCert
+        private SelfSignedCertificate certificate;
+
+        @RestResource
+        private Client client;
+
+        @RestResource
+        @RequestPath("info/request-uri")
+        private URI baseUri;
+
+        @Test
+        public void fullClientAuthWorks() {
+            Assertions.assertEquals("https", baseUri.getScheme());
+            final String result = client.target(baseUri)
+                    .request()
+                    .get(String.class);
+            Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+        }
+
+        @Test
+        public void trustOnlyClientSucceeds() {
+            try (Client trustOnlyClient = ClientBuilder.newBuilder()
+                    .trustStore(certificate.clientTrustStore())
+                    .build()) {
+                final String result = trustOnlyClient.target(baseUri)
+                        .request()
+                        .get(String.class);
+                Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+            }
+        }
+    }
+
+    @Nested
+    @SelfSignedCert
+    @RestBootstrap(value = RequestInfoResource.class, sslClientAuthentication = SSLClientAuthentication.MANDATORY)
+    class MandatoryClientAuth {
+
+        @SslCert
+        private SelfSignedCertificate certificate;
+
+        @RestResource
+        private Client client;
+
+        @RestResource
+        @RequestPath("info/request-uri")
+        private URI baseUri;
+
+        @Test
+        public void fullClientAuthWorks() {
+            Assertions.assertEquals("https", baseUri.getScheme());
+            final String result = client.target(baseUri)
+                    .request()
+                    .get(String.class);
+            Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+        }
+
+        @Test
+        public void trustOnlyClientFails() {
+            try (Client trustOnlyClient = ClientBuilder.newBuilder()
+                    .trustStore(certificate.clientTrustStore())
+                    .build()) {
+                Assertions.assertThrows(ProcessingException.class, () -> trustOnlyClient.target(baseUri)
+                        .request()
+                        .get());
+            }
+        }
+    }
+
+    @Nested
+    @SelfSignedCert
+    @RestBootstrap(value = RequestInfoResource.class, sslClientAuthentication = SSLClientAuthentication.NONE)
+    class NoClientAuth {
+
+        @SslCert
+        private SelfSignedCertificate certificate;
+
+        @RestResource
+        private Client client;
+
+        @RestResource
+        @RequestPath("info/request-uri")
+        private URI baseUri;
+
+        @Test
+        public void fullClientAuthWorks() {
+            Assertions.assertEquals("https", baseUri.getScheme());
+            final String result = client.target(baseUri)
+                    .request()
+                    .get(String.class);
+            Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+        }
+
+        @Test
+        public void trustOnlyClientSucceeds() {
+            try (Client trustOnlyClient = ClientBuilder.newBuilder()
+                    .trustStore(certificate.clientTrustStore())
+                    .build()) {
+                final String result = trustOnlyClient.target(baseUri)
+                        .request()
+                        .get(String.class);
+                Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+            }
+        }
+    }
+}

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/SslCustomClientProviderTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/SslCustomClientProviderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.extension;
+
+import java.net.URI;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import dev.resteasy.junit.extension.annotations.RequestPath;
+import dev.resteasy.junit.extension.annotations.RestBootstrap;
+import dev.resteasy.junit.extension.annotations.RestClientConfig;
+import dev.resteasy.junit.extension.annotations.RestResource;
+import dev.resteasy.junit.extension.annotations.SelfSignedCert;
+import dev.resteasy.junit.extension.annotations.SslCert;
+import dev.resteasy.junit.extension.api.RestClientBuilderProvider;
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
+import dev.resteasy.junit.extension.extension.resources.RequestInfoResource;
+
+/**
+ * Tests that a custom {@link RestClientBuilderProvider} receives the {@link SelfSignedCertificate} via
+ * {@link SslCert @SslCert} field injection.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@SelfSignedCert
+@RestBootstrap(RequestInfoResource.class)
+public class SslCustomClientProviderTest {
+
+    public static class CustomSslClientProvider implements RestClientBuilderProvider {
+        @SslCert
+        private SelfSignedCertificate certificate;
+
+        @Override
+        public ClientBuilder getClientBuilder() {
+            Assertions.assertNotNull(certificate, "Certificate should be injected into RestClientBuilderProvider");
+            return ClientBuilder.newBuilder()
+                    .sslContext(certificate.clientSslContext());
+        }
+    }
+
+    @RestResource
+    @RestClientConfig(CustomSslClientProvider.class)
+    private Client client;
+
+    @RestResource
+    @RequestPath("info/request-uri")
+    private URI baseUri;
+
+    @Test
+    public void customClientProviderWorksOverHttps() {
+        final String result = client.target(baseUri)
+                .request()
+                .get(String.class);
+        Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+    }
+}

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/SslCustomConfigProviderTest.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/SslCustomConfigProviderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.extension;
+
+import java.net.URI;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.client.Client;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import dev.resteasy.junit.extension.annotations.RequestPath;
+import dev.resteasy.junit.extension.annotations.RestBootstrap;
+import dev.resteasy.junit.extension.annotations.RestResource;
+import dev.resteasy.junit.extension.annotations.SelfSignedCert;
+import dev.resteasy.junit.extension.annotations.SslCert;
+import dev.resteasy.junit.extension.api.ConfigurationProvider;
+import dev.resteasy.junit.extension.api.SelfSignedCertificate;
+import dev.resteasy.junit.extension.extension.resources.RequestInfoResource;
+
+/**
+ * Tests that a custom {@link ConfigurationProvider} receives the {@link SelfSignedCertificate} via
+ * {@link SslCert @SslCert} field injection.
+ *
+ * @author <a href="mailto:jperkins@ibm.com">James R. Perkins</a>
+ */
+@SelfSignedCert
+@RestBootstrap(value = RequestInfoResource.class, configFactory = SslCustomConfigProviderTest.CustomSslConfigProvider.class)
+public class SslCustomConfigProviderTest {
+
+    public static class CustomSslConfigProvider implements ConfigurationProvider {
+        @SslCert
+        private SelfSignedCertificate certificate;
+
+        @Override
+        public SeBootstrap.Configuration getConfiguration(final ExtensionContext context) {
+            Assertions.assertNotNull(certificate, "Certificate should be injected into ConfigurationProvider");
+            return SeBootstrap.Configuration.builder()
+                    .protocol("HTTPS")
+                    .sslContext(certificate.serverSslContext())
+                    .build();
+        }
+    }
+
+    @RestResource
+    private Client client;
+
+    @RestResource
+    @RequestPath("info/request-uri")
+    private URI baseUri;
+
+    @Test
+    public void serverUsesHttps() {
+        Assertions.assertEquals("https", baseUri.getScheme(),
+                "Server should be running on HTTPS with custom ConfigurationProvider");
+    }
+
+    @Test
+    public void clientCanCommunicate() {
+        final String result = client.target(baseUri)
+                .request()
+                .get(String.class);
+        Assertions.assertEquals("https://localhost:8081/info/request-uri", result);
+    }
+}

--- a/extension/src/test/java/dev/resteasy/junit/extension/extension/resources/RequestInfoResource.java
+++ b/extension/src/test/java/dev/resteasy/junit/extension/extension/resources/RequestInfoResource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The RESTEasy Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dev.resteasy.junit.extension.extension.resources;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Path("/info")
+public class RequestInfoResource {
+
+    @Context
+    private UriInfo uriInfo;
+
+    @GET
+    @Path("/request-uri")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String requestUri() {
+        return uriInfo.getRequestUri().toString();
+    }
+}


### PR DESCRIPTION
Generates self-signed server and client certificates using the JDK keytool. When combined with @RestBootstrap, the server is automatically started with HTTPS and injected Client instances are configured with the client SSLContext.

@SelfSignedCert can also be used standalone without @RestBootstrap for scenarios that only need the certificate artifacts.

The generated SelfSignedCertificate can be injected into test fields and provider implementations using the @SslCert annotation.